### PR TITLE
Bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,9 @@
 import Dependencies._
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+.enablePlugins(JavaAgent)
+.settings(javaAgents += "org.aspectj" % "aspectjweaver" % "1.8.11"  % "runtime")
+.settings(
     inThisBuild(List(
       organization := "com.example",
       scalaVersion := "2.12.4",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,7 @@ object Dependencies {
     "io.kamon"                         %% "kamon-core"                  % "1.1.0",
     "io.kamon"                         %% "kamon-http4s"                % "1.0.4",
     "io.kamon"                         %% "kamon-executors"             % "1.0.1",
-    "io.kamon"                         %% "kamon-logback"               % "1.0.0"
+    "io.kamon"                         %% "kamon-logback"               % "1.0.0",
+    "io.kamon"                         %% "kamon-scala-future"          % "1.0.0"
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")

--- a/src/main/scala/example/Api.scala
+++ b/src/main/scala/example/Api.scala
@@ -23,9 +23,9 @@ class Api(client: Client[IO]) extends Logging {
         for {
           ping     <- req.as[Ping]
           _        <- IO { logger.info(s"Got $ping") }
-          pang     <- client.expect[Pang](Request[IO](POST, Uri.unsafeFromString(s"http://localhost:$port/pang")).withBody(ping).unsafeRunSync())
+          pang     <- client.expect[Pang](Request[IO](POST, Uri.unsafeFromString(s"http://localhost:$port/pang")).withBody(ping))
           _        <- IO { logger.info(s"Got $pang") }
-          peng     <- client.expect[Peng](Request[IO](POST, Uri.unsafeFromString(s"http://localhost:$port/peng")).withBody(ping).unsafeRunSync())
+          peng     <- client.expect[Peng](Request[IO](POST, Uri.unsafeFromString(s"http://localhost:$port/peng")).withBody(ping))
           _        <- IO { logger.info(s"Got $peng") }
           pong     <- IO { Pong(s"${ping.msg} ${pang.msg} ${peng.msg}") }
           _        <- IO { logger.info(s"Responding $pong") }


### PR DESCRIPTION
@aggenebbisj we found that when the client uses the [EntityBodyWriter][1] and their methods that return [Futures][2] the `Context` is lost. In order to properly propagate the `Kamon Context` throgh the `Futures` we can use the `kamon-scala-futures` module. I've just done a PR in your `bug` branch in order to show how fix this issue

[1]:https://github.com/http4s/http4s/blob/master/blaze-core/src/main/scala/org/http4s/blazecore/util/EntityBodyWriter.scala#L11-L40

[2]:https://github.com/http4s/http4s/blob/master/blaze-core/src/main/scala/org/http4s/blazecore/util/Http1Writer.scala#L12-L21